### PR TITLE
fast for local repository

### DIFF
--- a/internal/cli/command_releases.go
+++ b/internal/cli/command_releases.go
@@ -145,13 +145,14 @@ func (c *CliContextWrapper) Option() (*core.Option, error) {
 	}
 
 	return &core.Option{
-		Since:            c.Since(),
-		Until:            c.Until(),
-		IgnorePattern:    ignorePattern,
-		FixCommitPattern: fixCommitPattern,
-		StartTimerFunc:   c.StartTimer,
-		StopTimerFunc:    c.StopTimer,
-		DebuglnFunc:      c.Debugln,
+		Since:             c.Since(),
+		Until:             c.Until(),
+		IgnorePattern:     ignorePattern,
+		IsLocalRepository: c.context.String("repository") == "",
+		FixCommitPattern:  fixCommitPattern,
+		StartTimerFunc:    c.StartTimer,
+		StopTimerFunc:     c.StopTimer,
+		DebuglnFunc:       c.Debugln,
 	}, nil
 }
 

--- a/internal/core/query_releases_test.go
+++ b/internal/core/query_releases_test.go
@@ -85,30 +85,7 @@ func TestQueryReleasesShouldReturnReleasesWithSpecifiedTimeRange(t *testing.T) {
 	tag5_2_0 := &Release{Tag: "v5.2.0", Date: time.Date(2020, 10, 9, 11, 49, 30, 0, time.FixedZone("+0200", 2*60*60)), Result: ReleaseResult{IsSuccess: true}}
 	expectedTags := []*Release{tag5_2_0, tag5_1_0, tag5_0_0}
 
-	if len(releases) != len(expectedTags) {
-		t.Errorf("releases does not have expected tag num. expected: %v. actual: %v", len(expectedTags), len(releases))
-		return
-	}
-
-	unmatchedRelease := make([]int, 0)
-	for i, actual := range releases {
-		expected := expectedTags[i]
-		if actual.Equal(expected) {
-			continue
-		}
-		unmatchedRelease = append(unmatchedRelease, i)
-	}
-
-	if len(unmatchedRelease) == 0 {
-		return
-	}
-
-	for i := range unmatchedRelease {
-		actual := releases[i]
-		expected := expectedTags[i]
-		t.Logf("releases[%d] = %s. expected: %v", i, actual, expected)
-	}
-	t.Errorf("releases does not have specified")
+	assertReleasesAreEqual(t, expectedTags, releases)
 }
 
 func TestQueryReleasesShouldHaveReleaseResult(t *testing.T) {
@@ -145,30 +122,7 @@ func TestQueryReleasesShouldHaveReleaseResult(t *testing.T) {
 	}
 	expectedTags := []*Release{tag2_1_2, tag2_1_1, tag2_1_0}
 
-	if len(releases) != len(expectedTags) {
-		t.Errorf("releases does not have expected tag num. expected: %v. actual: %v", len(expectedTags), len(releases))
-		return
-	}
-
-	unmatchedRelease := make([]int, 0)
-	for i, actual := range releases {
-		expected := expectedTags[i]
-		if actual.Equal(expected) {
-			continue
-		}
-		unmatchedRelease = append(unmatchedRelease, i)
-	}
-
-	if len(unmatchedRelease) == 0 {
-		return
-	}
-
-	for i := range unmatchedRelease {
-		actual := releases[i]
-		expected := expectedTags[i]
-		t.Logf("releases[%d] = %s. expected: %v", i, actual, expected)
-	}
-	t.Errorf("releases does not have specified")
+	assertReleasesAreEqual(t, expectedTags, releases)
 }
 
 func TestQueryReleasesShouldReturnReleasesWithIgnorePattern(t *testing.T) {


### PR DESCRIPTION
When repository is local, use git command.
When repository is remote, use go-git.
Git command is x1.5 faster than go-git.

<details>
<summary>[Local Repository] QueryReleases        1.925479333s</summary>

```sh
$ time ../four-keys/four-keys --debug --since 2000-01-01                                2321ms  木  7/28 22:09:43 2022
[Debug] In debug mode
[Debug] StartTimer: Open Repository
[Debug] Stop_Timer: Open Repository      132.875µs
[Debug] StartTimer: QueryReleases
[Debug] StartTimer: QueryTags
[Debug] Stop_Timer: QueryTags    1.171792ms
[Debug] Tags count: 141
[Debug] Sources count: 141
[Debug] StartTimer: source[0](v18.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[0](v18.2.0)GetReleaseMetrics          19.060167ms
[Debug] StartTimer: source[1](v18.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[1](v18.1.0)GetReleaseMetrics          13.683208ms
[Debug] StartTimer: source[2](v18.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[2](v18.0.0)GetReleaseMetrics          25.080166ms
[Debug] StartTimer: source[3](v17.0.2)GetReleaseMetrics
[Debug] Stop_Timer: source[3](v17.0.2)GetReleaseMetrics          13.158833ms
[Debug] StartTimer: source[4](v0.0.0-experimental-27659559e)GetReleaseMetrics
[Debug] Stop_Timer: source[4](v0.0.0-experimental-27659559e)GetReleaseMetrics    13.698625ms
[Debug] StartTimer: source[5](v17.0.1)GetReleaseMetrics
[Debug] Stop_Timer: source[5](v17.0.1)GetReleaseMetrics          11.225791ms
[Debug] StartTimer: source[6](v17.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[6](v17.0.0)GetReleaseMetrics          11.974459ms
[Debug] StartTimer: source[7](v16.14.0)GetReleaseMetrics
[Debug] Stop_Timer: source[7](v16.14.0)GetReleaseMetrics         11.773625ms
[Debug] StartTimer: source[8](v15.7.0)GetReleaseMetrics
[Debug] Stop_Timer: source[8](v15.7.0)GetReleaseMetrics          11.483292ms
[Debug] StartTimer: source[9](0.14.10)GetReleaseMetrics
[Debug] Stop_Timer: source[9](0.14.10)GetReleaseMetrics          24.6845ms
[Debug] StartTimer: source[10](v0.0.0-d7382b6c4)GetReleaseMetrics
[Debug] Stop_Timer: source[10](v0.0.0-d7382b6c4)GetReleaseMetrics        10.612458ms
[Debug] StartTimer: source[11](v0.0.0-experimental-d7382b6c4)GetReleaseMetrics
[Debug] Stop_Timer: source[11](v0.0.0-experimental-d7382b6c4)GetReleaseMetrics   16.158625ms
[Debug] StartTimer: source[12](v16.13.1)GetReleaseMetrics
[Debug] Stop_Timer: source[12](v16.13.1)GetReleaseMetrics        10.436208ms
[Debug] StartTimer: source[13](v0.0.0-experimental-aae83a4b9)GetReleaseMetrics
[Debug] Stop_Timer: source[13](v0.0.0-experimental-aae83a4b9)GetReleaseMetrics   11.497833ms
[Debug] StartTimer: source[14](v0.0.0-experimental-8b155d261)GetReleaseMetrics
[Debug] Stop_Timer: source[14](v0.0.0-experimental-8b155d261)GetReleaseMetrics   12.188959ms
[Debug] StartTimer: source[15](v16.13.0)GetReleaseMetrics
[Debug] Stop_Timer: source[15](v16.13.0)GetReleaseMetrics        14.509791ms
[Debug] StartTimer: source[16](v16.12.0)GetReleaseMetrics
[Debug] Stop_Timer: source[16](v16.12.0)GetReleaseMetrics        12.171958ms
[Debug] StartTimer: source[17](v16.11.0)GetReleaseMetrics
[Debug] Stop_Timer: source[17](v16.11.0)GetReleaseMetrics        10.812209ms
[Debug] StartTimer: source[18](status)GetReleaseMetrics
[Debug] Stop_Timer: source[18](status)GetReleaseMetrics          11.632291ms
[Debug] StartTimer: source[19](v16.10.2)GetReleaseMetrics
[Debug] Stop_Timer: source[19](v16.10.2)GetReleaseMetrics        12.016792ms
[Debug] StartTimer: source[20](v16.10.1)GetReleaseMetrics
[Debug] Stop_Timer: source[20](v16.10.1)GetReleaseMetrics        13.613208ms
[Debug] StartTimer: source[21](v16.10.0)GetReleaseMetrics
[Debug] Stop_Timer: source[21](v16.10.0)GetReleaseMetrics        18.262084ms
[Debug] StartTimer: source[22](v16.9.0)GetReleaseMetrics
[Debug] Stop_Timer: source[22](v16.9.0)GetReleaseMetrics         12.185833ms
[Debug] StartTimer: source[23](v16.9.0-rc.0)GetReleaseMetrics
[Debug] Stop_Timer: source[23](v16.9.0-rc.0)GetReleaseMetrics    16.87925ms
[Debug] StartTimer: source[24](v16.9.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[24](v16.9.0-alpha.0)GetReleaseMetrics         11.5545ms
[Debug] StartTimer: source[25](1.2.5)GetReleaseMetrics
[Debug] Stop_Timer: source[25](1.2.5)GetReleaseMetrics   10.845291ms
[Debug] StartTimer: source[26](v16.8.6)GetReleaseMetrics
[Debug] Stop_Timer: source[26](v16.8.6)GetReleaseMetrics         10.380791ms
[Debug] StartTimer: source[27](v16.8.5)GetReleaseMetrics
[Debug] Stop_Timer: source[27](v16.8.5)GetReleaseMetrics         11.204375ms
[Debug] StartTimer: source[28](v16.8.4)GetReleaseMetrics
[Debug] Stop_Timer: source[28](v16.8.4)GetReleaseMetrics         11.314708ms
[Debug] StartTimer: source[29](v16.8.3)GetReleaseMetrics
[Debug] Stop_Timer: source[29](v16.8.3)GetReleaseMetrics         10.881167ms
[Debug] StartTimer: source[30](v16.8.2)GetReleaseMetrics
[Debug] Stop_Timer: source[30](v16.8.2)GetReleaseMetrics         12.352125ms
[Debug] StartTimer: source[31](v16.8.1)GetReleaseMetrics
[Debug] Stop_Timer: source[31](v16.8.1)GetReleaseMetrics         11.71775ms
[Debug] StartTimer: source[32](v16.8.0)GetReleaseMetrics
[Debug] Stop_Timer: source[32](v16.8.0)GetReleaseMetrics         12.811208ms
[Debug] StartTimer: source[33](v16.8.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[33](v16.8.0-alpha.1)GetReleaseMetrics         12.911708ms
[Debug] StartTimer: source[34](v16.7.0)GetReleaseMetrics
[Debug] Stop_Timer: source[34](v16.7.0)GetReleaseMetrics         13.011958ms
[Debug] StartTimer: source[35](v0.0.0-88ada9819)GetReleaseMetrics
[Debug] Stop_Timer: source[35](v0.0.0-88ada9819)GetReleaseMetrics        12.683125ms
[Debug] StartTimer: source[36](v16.7.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[36](v16.7.0-alpha.1)GetReleaseMetrics         12.4725ms
[Debug] StartTimer: source[37](v16.6.3)GetReleaseMetrics
[Debug] Stop_Timer: source[37](v16.6.3)GetReleaseMetrics         11.427958ms
[Debug] StartTimer: source[38](v16.6.1)GetReleaseMetrics
[Debug] Stop_Timer: source[38](v16.6.1)GetReleaseMetrics         12.745458ms
[Debug] StartTimer: source[39](v16.6.0)GetReleaseMetrics
[Debug] Stop_Timer: source[39](v16.6.0)GetReleaseMetrics         13.154208ms
[Debug] StartTimer: source[40](v16.6.0-alpha.8af6728)GetReleaseMetrics
[Debug] Stop_Timer: source[40](v16.6.0-alpha.8af6728)GetReleaseMetrics   12.524625ms
[Debug] StartTimer: source[41](v16.6.0-alpha.400d197)GetReleaseMetrics
[Debug] Stop_Timer: source[41](v16.6.0-alpha.400d197)GetReleaseMetrics   11.911291ms
[Debug] StartTimer: source[42](v16.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[42](v16.5.2)GetReleaseMetrics         13.820916ms
[Debug] StartTimer: source[43](v16.6.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[43](v16.6.0-alpha.0)GetReleaseMetrics         13.443541ms
[Debug] StartTimer: source[44](v16.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[44](v16.5.1)GetReleaseMetrics         11.520334ms
[Debug] StartTimer: source[45](v16.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[45](v16.5.0)GetReleaseMetrics         12.763666ms
[Debug] StartTimer: source[46](v16.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[46](v16.4.2)GetReleaseMetrics         11.246959ms
[Debug] StartTimer: source[47](v16.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[47](v16.4.1)GetReleaseMetrics         11.924959ms
[Debug] StartTimer: source[48](v16.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[48](v16.4.0)GetReleaseMetrics         13.132333ms
[Debug] StartTimer: source[49](v16.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[49](v16.3.2)GetReleaseMetrics         11.000042ms
[Debug] StartTimer: source[50](v16.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[50](v16.3.1)GetReleaseMetrics         11.7645ms
[Debug] StartTimer: source[51](v16.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[51](v16.3.0)GetReleaseMetrics         11.590583ms
[Debug] StartTimer: source[52](v16.3.0-rc.0)GetReleaseMetrics
[Debug] Stop_Timer: source[52](v16.3.0-rc.0)GetReleaseMetrics    10.917708ms
[Debug] StartTimer: source[53](v16.3.0-alpha.3)GetReleaseMetrics
[Debug] Stop_Timer: source[53](v16.3.0-alpha.3)GetReleaseMetrics         11.735042ms
[Debug] StartTimer: source[54](v16.3.0-alpha.2)GetReleaseMetrics
[Debug] Stop_Timer: source[54](v16.3.0-alpha.2)GetReleaseMetrics         11.055958ms
[Debug] StartTimer: source[55](v16.4.0-alpha.94a255d)GetReleaseMetrics
[Debug] Stop_Timer: source[55](v16.4.0-alpha.94a255d)GetReleaseMetrics   10.966416ms
[Debug] StartTimer: source[56](v16.4.0-alpha.5a25959)GetReleaseMetrics
[Debug] Stop_Timer: source[56](v16.4.0-alpha.5a25959)GetReleaseMetrics   11.23875ms
[Debug] StartTimer: source[57](v16.4.0-alpha.16.4.0-alpha.7926752)GetReleaseMetrics
[Debug] Stop_Timer: source[57](v16.4.0-alpha.16.4.0-alpha.7926752)GetReleaseMetrics      10.820708ms
[Debug] StartTimer: source[58](v16.3.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[58](v16.3.0-alpha.1)GetReleaseMetrics         10.937792ms
[Debug] StartTimer: source[59](v16.3.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[59](v16.3.0-alpha.0)GetReleaseMetrics         14.077958ms
[Debug] StartTimer: source[60](v16.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[60](v16.2.0)GetReleaseMetrics         11.661708ms
[Debug] StartTimer: source[61](v16.1.1)GetReleaseMetrics
[Debug] Stop_Timer: source[61](v16.1.1)GetReleaseMetrics         11.352708ms
[Debug] StartTimer: source[62](v16.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[62](v16.1.0)GetReleaseMetrics         10.636959ms
[Debug] StartTimer: source[63](16.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[63](16.1.0)GetReleaseMetrics          12.317959ms
[Debug] StartTimer: source[64](16.1.0-rc)GetReleaseMetrics
[Debug] Stop_Timer: source[64](16.1.0-rc)GetReleaseMetrics       11.363792ms
[Debug] StartTimer: source[65](16.1.0-beta.1)GetReleaseMetrics
[Debug] Stop_Timer: source[65](16.1.0-beta.1)GetReleaseMetrics   11.087625ms
[Debug] StartTimer: source[66](16.1.0-beta)GetReleaseMetrics
[Debug] Stop_Timer: source[66](16.1.0-beta)GetReleaseMetrics     17.10425ms
[Debug] StartTimer: source[67](v16.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[67](v16.0.0)GetReleaseMetrics         10.319834ms
[Debug] StartTimer: source[68](v15.6.2)GetReleaseMetrics
[Debug] Stop_Timer: source[68](v15.6.2)GetReleaseMetrics         11.470292ms
[Debug] StartTimer: source[69](v16.0.0-rc.2)GetReleaseMetrics
[Debug] Stop_Timer: source[69](v16.0.0-rc.2)GetReleaseMetrics    11.335416ms
[Debug] StartTimer: source[70](v16.0.0-rc.1)GetReleaseMetrics
[Debug] Stop_Timer: source[70](v16.0.0-rc.1)GetReleaseMetrics    13.945375ms
[Debug] StartTimer: source[71](16.0.0-beta.5)GetReleaseMetrics
[Debug] Stop_Timer: source[71](16.0.0-beta.5)GetReleaseMetrics   13.9425ms
[Debug] StartTimer: source[72](16.0.0-beta.4)GetReleaseMetrics
[Debug] Stop_Timer: source[72](16.0.0-beta.4)GetReleaseMetrics   11.45575ms
[Debug] StartTimer: source[73](16.0.0-beta.3)GetReleaseMetrics
[Debug] Stop_Timer: source[73](16.0.0-beta.3)GetReleaseMetrics   11.18725ms
[Debug] StartTimer: source[74](16.0.0-beta.1)GetReleaseMetrics
[Debug] Stop_Timer: source[74](16.0.0-beta.1)GetReleaseMetrics   14.31475ms
[Debug] StartTimer: source[75](v15.6.1)GetReleaseMetrics
[Debug] Stop_Timer: source[75](v15.6.1)GetReleaseMetrics         14.195792ms
[Debug] StartTimer: source[76](v15.6.0)GetReleaseMetrics
[Debug] Stop_Timer: source[76](v15.6.0)GetReleaseMetrics         14.075917ms
[Debug] StartTimer: source[77](v15.5.4)GetReleaseMetrics
[Debug] Stop_Timer: source[77](v15.5.4)GetReleaseMetrics         11.7985ms
[Debug] StartTimer: source[78](v15.5.3)GetReleaseMetrics
[Debug] Stop_Timer: source[78](v15.5.3)GetReleaseMetrics         12.179125ms
[Debug] StartTimer: source[79](v15.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[79](v15.5.2)GetReleaseMetrics         11.359334ms
[Debug] StartTimer: source[80](v15.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[80](v15.5.1)GetReleaseMetrics         15.467917ms
[Debug] StartTimer: source[81](v15.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[81](v15.5.0)GetReleaseMetrics         12.006125ms
[Debug] StartTimer: source[82](15.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[82](15.3.2)GetReleaseMetrics          11.325583ms
[Debug] StartTimer: source[83](v16.0.0-alpha.4)GetReleaseMetrics
[Debug] Stop_Timer: source[83](v16.0.0-alpha.4)GetReleaseMetrics         13.129167ms
[Debug] StartTimer: source[84](v16.0.0-alpha.3)GetReleaseMetrics
[Debug] Stop_Timer: source[84](v16.0.0-alpha.3)GetReleaseMetrics         16.949875ms
[Debug] StartTimer: source[85](v15.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[85](v15.4.2)GetReleaseMetrics         13.537791ms
[Debug] StartTimer: source[86](v15.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[86](v15.4.1)GetReleaseMetrics         11.001833ms
[Debug] StartTimer: source[87](v15.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[87](v15.4.0)GetReleaseMetrics         11.530083ms
[Debug] StartTimer: source[88](v15.4.0-rc.3)GetReleaseMetrics
[Debug] Stop_Timer: source[88](v15.4.0-rc.3)GetReleaseMetrics    13.095125ms
[Debug] StartTimer: source[89](v15.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[89](v15.3.2)GetReleaseMetrics         14.113709ms
[Debug] StartTimer: source[90](15.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[90](15.3.1)GetReleaseMetrics          10.828541ms
[Debug] StartTimer: source[91](v15.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[91](v15.3.1)GetReleaseMetrics         10.475084ms
[Debug] StartTimer: source[92](v15.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[92](v15.3.0)GetReleaseMetrics         16.123208ms
[Debug] StartTimer: source[93](v15.2.1)GetReleaseMetrics
[Debug] Stop_Timer: source[93](v15.2.1)GetReleaseMetrics         11.866375ms
[Debug] StartTimer: source[94](v15.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[94](v15.2.0)GetReleaseMetrics         13.449416ms
[Debug] StartTimer: source[95](v15.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[95](v15.1.0)GetReleaseMetrics         11.836083ms
[Debug] StartTimer: source[96](v15.0.2)GetReleaseMetrics
[Debug] Stop_Timer: source[96](v15.0.2)GetReleaseMetrics         12.21575ms
[Debug] StartTimer: source[97](v15.0.1)GetReleaseMetrics
[Debug] Stop_Timer: source[97](v15.0.1)GetReleaseMetrics         12.898792ms
[Debug] StartTimer: source[98](v15.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[98](v15.0.0)GetReleaseMetrics         16.135625ms
[Debug] StartTimer: source[99](v0.14.8)GetReleaseMetrics
[Debug] Stop_Timer: source[99](v0.14.8)GetReleaseMetrics         11.041917ms
[Debug] StartTimer: source[100](v15.0.0-rc.2)GetReleaseMetrics
[Debug] Stop_Timer: source[100](v15.0.0-rc.2)GetReleaseMetrics   14.141291ms
[Debug] StartTimer: source[101](v15.0.0-rc.1)GetReleaseMetrics
[Debug] Stop_Timer: source[101](v15.0.0-rc.1)GetReleaseMetrics   16.066625ms
[Debug] StartTimer: source[102](v0.14.7)GetReleaseMetrics
[Debug] Stop_Timer: source[102](v0.14.7)GetReleaseMetrics        11.083042ms
[Debug] StartTimer: source[103](v0.14.6)GetReleaseMetrics
[Debug] Stop_Timer: source[103](v0.14.6)GetReleaseMetrics        14.606583ms
[Debug] StartTimer: source[104](v0.14.5)GetReleaseMetrics
[Debug] Stop_Timer: source[104](v0.14.5)GetReleaseMetrics        11.31375ms
[Debug] StartTimer: source[105](v0.14.4)GetReleaseMetrics
[Debug] Stop_Timer: source[105](v0.14.4)GetReleaseMetrics        13.113542ms
[Debug] StartTimer: source[106](v0.14.3)GetReleaseMetrics
[Debug] Stop_Timer: source[106](v0.14.3)GetReleaseMetrics        11.643208ms
[Debug] StartTimer: source[107](v0.14.2)GetReleaseMetrics
[Debug] Stop_Timer: source[107](v0.14.2)GetReleaseMetrics        13.250667ms
[Debug] StartTimer: source[108](v0.14.1)GetReleaseMetrics
[Debug] Stop_Timer: source[108](v0.14.1)GetReleaseMetrics        12.002459ms
[Debug] StartTimer: source[109](v0.14.0)GetReleaseMetrics
[Debug] Stop_Timer: source[109](v0.14.0)GetReleaseMetrics        25.897708ms
[Debug] StartTimer: source[110](v0.14.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[110](v0.14.0-rc1)GetReleaseMetrics    17.002958ms
[Debug] StartTimer: source[111](v0.14.0-beta3)GetReleaseMetrics
[Debug] Stop_Timer: source[111](v0.14.0-beta3)GetReleaseMetrics          11.215625ms
[Debug] StartTimer: source[112](v0.14.0-beta2)GetReleaseMetrics
[Debug] Stop_Timer: source[112](v0.14.0-beta2)GetReleaseMetrics          24.890708ms
[Debug] StartTimer: source[113](v0.14.0-beta1)GetReleaseMetrics
[Debug] Stop_Timer: source[113](v0.14.0-beta1)GetReleaseMetrics          16.9295ms
[Debug] StartTimer: source[114](v0.13.3)GetReleaseMetrics
[Debug] Stop_Timer: source[114](v0.13.3)GetReleaseMetrics        11.157875ms
[Debug] StartTimer: source[115](v0.13.2)GetReleaseMetrics
[Debug] Stop_Timer: source[115](v0.13.2)GetReleaseMetrics        11.447458ms
[Debug] StartTimer: source[116](v0.13.1)GetReleaseMetrics
[Debug] Stop_Timer: source[116](v0.13.1)GetReleaseMetrics        14.087208ms
[Debug] StartTimer: source[117](v0.13.0)GetReleaseMetrics
[Debug] Stop_Timer: source[117](v0.13.0)GetReleaseMetrics        14.377584ms
[Debug] StartTimer: source[118](v0.13.0-rc2)GetReleaseMetrics
[Debug] Stop_Timer: source[118](v0.13.0-rc2)GetReleaseMetrics    11.510625ms
[Debug] StartTimer: source[119](v0.13.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[119](v0.13.0-rc1)GetReleaseMetrics    21.056792ms
[Debug] StartTimer: source[120](v0.12.2)GetReleaseMetrics
[Debug] Stop_Timer: source[120](v0.12.2)GetReleaseMetrics        11.567875ms
[Debug] StartTimer: source[121](v0.12.1)GetReleaseMetrics
[Debug] Stop_Timer: source[121](v0.12.1)GetReleaseMetrics        14.533125ms
[Debug] StartTimer: source[122](v0.12.0)GetReleaseMetrics
[Debug] Stop_Timer: source[122](v0.12.0)GetReleaseMetrics        17.626625ms
[Debug] StartTimer: source[123](v0.12.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[123](v0.12.0-rc1)GetReleaseMetrics    19.301333ms
[Debug] StartTimer: source[124](v0.11.2)GetReleaseMetrics
[Debug] Stop_Timer: source[124](v0.11.2)GetReleaseMetrics        12.243417ms
[Debug] StartTimer: source[125](v0.11.1)GetReleaseMetrics
[Debug] Stop_Timer: source[125](v0.11.1)GetReleaseMetrics        11.07825ms
[Debug] StartTimer: source[126](v0.11.0)GetReleaseMetrics
[Debug] Stop_Timer: source[126](v0.11.0)GetReleaseMetrics        14.489416ms
[Debug] StartTimer: source[127](v0.11.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[127](v0.11.0-rc1)GetReleaseMetrics    21.2515ms
[Debug] StartTimer: source[128](v0.10.0)GetReleaseMetrics
[Debug] Stop_Timer: source[128](v0.10.0)GetReleaseMetrics        14.160125ms
[Debug] StartTimer: source[129](v0.10.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[129](v0.10.0-rc1)GetReleaseMetrics    16.254875ms
[Debug] StartTimer: source[130](v0.9.0)GetReleaseMetrics
[Debug] Stop_Timer: source[130](v0.9.0)GetReleaseMetrics         15.674208ms
[Debug] StartTimer: source[131](v0.9.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[131](v0.9.0-rc1)GetReleaseMetrics     17.848584ms
[Debug] StartTimer: source[132](v0.8.0)GetReleaseMetrics
[Debug] Stop_Timer: source[132](v0.8.0)GetReleaseMetrics         11.868416ms
[Debug] StartTimer: source[133](v0.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[133](v0.5.2)GetReleaseMetrics         13.323792ms
[Debug] StartTimer: source[134](v0.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[134](v0.4.2)GetReleaseMetrics         13.245ms
[Debug] StartTimer: source[135](v0.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[135](v0.5.1)GetReleaseMetrics         11.24375ms
[Debug] StartTimer: source[136](v0.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[136](v0.5.0)GetReleaseMetrics         13.571083ms
[Debug] StartTimer: source[137](v0.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[137](v0.4.1)GetReleaseMetrics         11.275917ms
[Debug] StartTimer: source[138](v0.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[138](v0.4.0)GetReleaseMetrics         17.175959ms
[Debug] StartTimer: source[139](v0.3.3)GetReleaseMetrics
[Debug] Stop_Timer: source[139](v0.3.3)GetReleaseMetrics         13.752209ms
[Debug] StartTimer: source[140](v0.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[140](v0.3.0)GetReleaseMetrics         11.106333ms
[Debug] Stop_Timer: QueryReleases        1.925479333s
[Debug] StartTimer: Calculate metrics
[Debug] Stop_Timer: Calculate metrics    216.417µs
{"option":{"since":"2000-01-01T00:00:00Z","until":"2022-07-28T22:09:52.303576+09:00"},"deploymentFrequency":0.01710334788937409,"leadTimeForChanges":{"value":0,"unit":"day"},"timeToRestore":{"value":110.39109953703705,"unit":"day"},"changeFailureRate":0.014184397163120567}
________________________________________________________
Executed in    1.94 secs      fish           external
   usr time  789.80 millis    0.09 millis  789.72 millis
   sys time  665.85 millis    1.51 millis  664.34 millis
```

</details>

<details>
<summary>[Remote Repository] QueryReleases        3.003893708s</summary>

```sh
 time ./four-keys/four-keys --debug --since 2000-01-01 --repository https://github.com/facebook/react.git
[Debug] In debug mode
[Debug] StartTimer: Open Repository
[Debug] Stop_Timer: Open Repository      50.976566625s
[Debug] StartTimer: QueryReleases
[Debug] StartTimer: QueryTags
[Debug] Stop_Timer: QueryTags    30.416µs
[Debug] Tags count: 141
[Debug] Sources count: 141
[Debug] StartTimer: source[0](v18.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[0](v18.2.0)GetReleaseMetrics          42.816916ms
[Debug] StartTimer: source[1](v18.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[1](v18.1.0)GetReleaseMetrics          41.347875ms
[Debug] StartTimer: source[2](v18.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[2](v18.0.0)GetReleaseMetrics          46.113958ms
[Debug] StartTimer: source[3](v17.0.2)GetReleaseMetrics
[Debug] Stop_Timer: source[3](v17.0.2)GetReleaseMetrics          36.814041ms
[Debug] StartTimer: source[4](v0.0.0-experimental-27659559e)GetReleaseMetrics
[Debug] Stop_Timer: source[4](v0.0.0-experimental-27659559e)GetReleaseMetrics    38.55025ms
[Debug] StartTimer: source[5](v17.0.1)GetReleaseMetrics
[Debug] Stop_Timer: source[5](v17.0.1)GetReleaseMetrics          43.030875ms
[Debug] StartTimer: source[6](v17.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[6](v17.0.0)GetReleaseMetrics          35.165917ms
[Debug] StartTimer: source[7](0.14.10)GetReleaseMetrics
[Debug] Stop_Timer: source[7](0.14.10)GetReleaseMetrics          34.506917ms
[Debug] StartTimer: source[8](v16.14.0)GetReleaseMetrics
[Debug] Stop_Timer: source[8](v16.14.0)GetReleaseMetrics         34.432792ms
[Debug] StartTimer: source[9](v15.7.0)GetReleaseMetrics
[Debug] Stop_Timer: source[9](v15.7.0)GetReleaseMetrics          34.625209ms
[Debug] StartTimer: source[10](v0.0.0-d7382b6c4)GetReleaseMetrics
[Debug] Stop_Timer: source[10](v0.0.0-d7382b6c4)GetReleaseMetrics        32.756834ms
[Debug] StartTimer: source[11](v0.0.0-experimental-d7382b6c4)GetReleaseMetrics
[Debug] Stop_Timer: source[11](v0.0.0-experimental-d7382b6c4)GetReleaseMetrics   32.671667ms
[Debug] StartTimer: source[12](v16.13.1)GetReleaseMetrics
[Debug] Stop_Timer: source[12](v16.13.1)GetReleaseMetrics        33.207125ms
[Debug] StartTimer: source[13](v0.0.0-experimental-aae83a4b9)GetReleaseMetrics
[Debug] Stop_Timer: source[13](v0.0.0-experimental-aae83a4b9)GetReleaseMetrics   36.937041ms
[Debug] StartTimer: source[14](v0.0.0-experimental-8b155d261)GetReleaseMetrics
[Debug] Stop_Timer: source[14](v0.0.0-experimental-8b155d261)GetReleaseMetrics   37.243ms
[Debug] StartTimer: source[15](v16.13.0)GetReleaseMetrics
[Debug] Stop_Timer: source[15](v16.13.0)GetReleaseMetrics        35.0795ms
[Debug] StartTimer: source[16](v16.12.0)GetReleaseMetrics
[Debug] Stop_Timer: source[16](v16.12.0)GetReleaseMetrics        33.781375ms
[Debug] StartTimer: source[17](v16.11.0)GetReleaseMetrics
[Debug] Stop_Timer: source[17](v16.11.0)GetReleaseMetrics        34.294709ms
[Debug] StartTimer: source[18](status)GetReleaseMetrics
[Debug] Stop_Timer: source[18](status)GetReleaseMetrics          33.28175ms
[Debug] StartTimer: source[19](v16.10.2)GetReleaseMetrics
[Debug] Stop_Timer: source[19](v16.10.2)GetReleaseMetrics        33.6185ms
[Debug] StartTimer: source[20](v16.10.1)GetReleaseMetrics
[Debug] Stop_Timer: source[20](v16.10.1)GetReleaseMetrics        31.872584ms
[Debug] StartTimer: source[21](v16.10.0)GetReleaseMetrics
[Debug] Stop_Timer: source[21](v16.10.0)GetReleaseMetrics        31.989125ms
[Debug] StartTimer: source[22](v16.9.0-rc.0)GetReleaseMetrics
[Debug] Stop_Timer: source[22](v16.9.0-rc.0)GetReleaseMetrics    30.512042ms
[Debug] StartTimer: source[23](v16.9.0)GetReleaseMetrics
[Debug] Stop_Timer: source[23](v16.9.0)GetReleaseMetrics         29.308ms
[Debug] StartTimer: source[24](v16.9.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[24](v16.9.0-alpha.0)GetReleaseMetrics         28.054708ms
[Debug] StartTimer: source[25](1.2.5)GetReleaseMetrics
[Debug] Stop_Timer: source[25](1.2.5)GetReleaseMetrics   374.167µs
[Debug] StartTimer: source[26](v16.8.6)GetReleaseMetrics
[Debug] Stop_Timer: source[26](v16.8.6)GetReleaseMetrics         27.657625ms
[Debug] StartTimer: source[27](v16.8.5)GetReleaseMetrics
[Debug] Stop_Timer: source[27](v16.8.5)GetReleaseMetrics         29.505583ms
[Debug] StartTimer: source[28](v16.8.4)GetReleaseMetrics
[Debug] Stop_Timer: source[28](v16.8.4)GetReleaseMetrics         29.714542ms
[Debug] StartTimer: source[29](v16.8.3)GetReleaseMetrics
[Debug] Stop_Timer: source[29](v16.8.3)GetReleaseMetrics         30.503666ms
[Debug] StartTimer: source[30](v16.8.2)GetReleaseMetrics
[Debug] Stop_Timer: source[30](v16.8.2)GetReleaseMetrics         28.826667ms
[Debug] StartTimer: source[31](v16.8.1)GetReleaseMetrics
[Debug] Stop_Timer: source[31](v16.8.1)GetReleaseMetrics         29.375917ms
[Debug] StartTimer: source[32](v16.8.0)GetReleaseMetrics
[Debug] Stop_Timer: source[32](v16.8.0)GetReleaseMetrics         30.336375ms
[Debug] StartTimer: source[33](v16.8.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[33](v16.8.0-alpha.1)GetReleaseMetrics         29.627ms
[Debug] StartTimer: source[34](v16.7.0)GetReleaseMetrics
[Debug] Stop_Timer: source[34](v16.7.0)GetReleaseMetrics         29.532834ms
[Debug] StartTimer: source[35](v0.0.0-88ada9819)GetReleaseMetrics
[Debug] Stop_Timer: source[35](v0.0.0-88ada9819)GetReleaseMetrics        29.393375ms
[Debug] StartTimer: source[36](v16.7.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[36](v16.7.0-alpha.1)GetReleaseMetrics         29.459083ms
[Debug] StartTimer: source[37](v16.6.3)GetReleaseMetrics
[Debug] Stop_Timer: source[37](v16.6.3)GetReleaseMetrics         29.588166ms
[Debug] StartTimer: source[38](v16.6.1)GetReleaseMetrics
[Debug] Stop_Timer: source[38](v16.6.1)GetReleaseMetrics         29.021625ms
[Debug] StartTimer: source[39](v16.6.0)GetReleaseMetrics
[Debug] Stop_Timer: source[39](v16.6.0)GetReleaseMetrics         30.081167ms
[Debug] StartTimer: source[40](v16.6.0-alpha.8af6728)GetReleaseMetrics
[Debug] Stop_Timer: source[40](v16.6.0-alpha.8af6728)GetReleaseMetrics   29.832709ms
[Debug] StartTimer: source[41](v16.6.0-alpha.400d197)GetReleaseMetrics
[Debug] Stop_Timer: source[41](v16.6.0-alpha.400d197)GetReleaseMetrics   29.909125ms
[Debug] StartTimer: source[42](v16.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[42](v16.5.2)GetReleaseMetrics         28.610417ms
[Debug] StartTimer: source[43](v16.6.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[43](v16.6.0-alpha.0)GetReleaseMetrics         28.108209ms
[Debug] StartTimer: source[44](v16.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[44](v16.5.1)GetReleaseMetrics         27.866292ms
[Debug] StartTimer: source[45](v16.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[45](v16.5.0)GetReleaseMetrics         28.453083ms
[Debug] StartTimer: source[46](v16.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[46](v16.4.2)GetReleaseMetrics         27.621292ms
[Debug] StartTimer: source[47](v16.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[47](v16.4.1)GetReleaseMetrics         27.969625ms
[Debug] StartTimer: source[48](v16.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[48](v16.4.0)GetReleaseMetrics         27.877334ms
[Debug] StartTimer: source[49](v16.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[49](v16.3.2)GetReleaseMetrics         27.100917ms
[Debug] StartTimer: source[50](v16.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[50](v16.3.1)GetReleaseMetrics         26.21575ms
[Debug] StartTimer: source[51](v16.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[51](v16.3.0)GetReleaseMetrics         27.268625ms
[Debug] StartTimer: source[52](v16.3.0-rc.0)GetReleaseMetrics
[Debug] Stop_Timer: source[52](v16.3.0-rc.0)GetReleaseMetrics    26.276042ms
[Debug] StartTimer: source[53](v16.3.0-alpha.3)GetReleaseMetrics
[Debug] Stop_Timer: source[53](v16.3.0-alpha.3)GetReleaseMetrics         26.05775ms
[Debug] StartTimer: source[54](v16.3.0-alpha.2)GetReleaseMetrics
[Debug] Stop_Timer: source[54](v16.3.0-alpha.2)GetReleaseMetrics         25.682542ms
[Debug] StartTimer: source[55](v16.4.0-alpha.94a255d)GetReleaseMetrics
[Debug] Stop_Timer: source[55](v16.4.0-alpha.94a255d)GetReleaseMetrics   26.832375ms
[Debug] StartTimer: source[56](v16.4.0-alpha.5a25959)GetReleaseMetrics
[Debug] Stop_Timer: source[56](v16.4.0-alpha.5a25959)GetReleaseMetrics   27.273541ms
[Debug] StartTimer: source[57](v16.4.0-alpha.16.4.0-alpha.7926752)GetReleaseMetrics
[Debug] Stop_Timer: source[57](v16.4.0-alpha.16.4.0-alpha.7926752)GetReleaseMetrics      26.136584ms
[Debug] StartTimer: source[58](v16.3.0-alpha.1)GetReleaseMetrics
[Debug] Stop_Timer: source[58](v16.3.0-alpha.1)GetReleaseMetrics         26.29025ms
[Debug] StartTimer: source[59](v16.3.0-alpha.0)GetReleaseMetrics
[Debug] Stop_Timer: source[59](v16.3.0-alpha.0)GetReleaseMetrics         25.469417ms
[Debug] StartTimer: source[60](v16.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[60](v16.2.0)GetReleaseMetrics         25.717375ms
[Debug] StartTimer: source[61](v16.1.1)GetReleaseMetrics
[Debug] Stop_Timer: source[61](v16.1.1)GetReleaseMetrics         28.906083ms
[Debug] StartTimer: source[62](v16.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[62](v16.1.0)GetReleaseMetrics         27.158625ms
[Debug] StartTimer: source[63](16.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[63](16.1.0)GetReleaseMetrics          25.816208ms
[Debug] StartTimer: source[64](16.1.0-rc)GetReleaseMetrics
[Debug] Stop_Timer: source[64](16.1.0-rc)GetReleaseMetrics       25.01625ms
[Debug] StartTimer: source[65](16.1.0-beta.1)GetReleaseMetrics
[Debug] Stop_Timer: source[65](16.1.0-beta.1)GetReleaseMetrics   23.154291ms
[Debug] StartTimer: source[66](16.1.0-beta)GetReleaseMetrics
[Debug] Stop_Timer: source[66](16.1.0-beta)GetReleaseMetrics     23.033875ms
[Debug] StartTimer: source[67](v16.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[67](v16.0.0)GetReleaseMetrics         23.0445ms
[Debug] StartTimer: source[68](v15.6.2)GetReleaseMetrics
[Debug] Stop_Timer: source[68](v15.6.2)GetReleaseMetrics         19.75775ms
[Debug] StartTimer: source[69](v16.0.0-rc.2)GetReleaseMetrics
[Debug] Stop_Timer: source[69](v16.0.0-rc.2)GetReleaseMetrics    22.588875ms
[Debug] StartTimer: source[70](v16.0.0-rc.1)GetReleaseMetrics
[Debug] Stop_Timer: source[70](v16.0.0-rc.1)GetReleaseMetrics    22.529375ms
[Debug] StartTimer: source[71](16.0.0-beta.5)GetReleaseMetrics
[Debug] Stop_Timer: source[71](16.0.0-beta.5)GetReleaseMetrics   23.584334ms
[Debug] StartTimer: source[72](16.0.0-beta.4)GetReleaseMetrics
[Debug] Stop_Timer: source[72](16.0.0-beta.4)GetReleaseMetrics   23.345834ms
[Debug] StartTimer: source[73](16.0.0-beta.3)GetReleaseMetrics
[Debug] Stop_Timer: source[73](16.0.0-beta.3)GetReleaseMetrics   23.521292ms
[Debug] StartTimer: source[74](16.0.0-beta.1)GetReleaseMetrics
[Debug] Stop_Timer: source[74](16.0.0-beta.1)GetReleaseMetrics   23.261542ms
[Debug] StartTimer: source[75](v15.6.1)GetReleaseMetrics
[Debug] Stop_Timer: source[75](v15.6.1)GetReleaseMetrics         20.445542ms
[Debug] StartTimer: source[76](v15.6.0)GetReleaseMetrics
[Debug] Stop_Timer: source[76](v15.6.0)GetReleaseMetrics         20.322709ms
[Debug] StartTimer: source[77](v15.5.4)GetReleaseMetrics
[Debug] Stop_Timer: source[77](v15.5.4)GetReleaseMetrics         19.022708ms
[Debug] StartTimer: source[78](v15.5.3)GetReleaseMetrics
[Debug] Stop_Timer: source[78](v15.5.3)GetReleaseMetrics         19.177125ms
[Debug] StartTimer: source[79](v15.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[79](v15.5.2)GetReleaseMetrics         19.204916ms
[Debug] StartTimer: source[80](v15.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[80](v15.5.1)GetReleaseMetrics         18.763417ms
[Debug] StartTimer: source[81](v15.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[81](v15.5.0)GetReleaseMetrics         18.939417ms
[Debug] StartTimer: source[82](15.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[82](15.3.2)GetReleaseMetrics          17.491292ms
[Debug] StartTimer: source[83](v16.0.0-alpha.4)GetReleaseMetrics
[Debug] Stop_Timer: source[83](v16.0.0-alpha.4)GetReleaseMetrics         20.655708ms
[Debug] StartTimer: source[84](v16.0.0-alpha.3)GetReleaseMetrics
[Debug] Stop_Timer: source[84](v16.0.0-alpha.3)GetReleaseMetrics         21.177042ms
[Debug] StartTimer: source[85](v15.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[85](v15.4.2)GetReleaseMetrics         18.679708ms
[Debug] StartTimer: source[86](v15.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[86](v15.4.1)GetReleaseMetrics         18.810083ms
[Debug] StartTimer: source[87](v15.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[87](v15.4.0)GetReleaseMetrics         18.039208ms
[Debug] StartTimer: source[88](v15.4.0-rc.3)GetReleaseMetrics
[Debug] Stop_Timer: source[88](v15.4.0-rc.3)GetReleaseMetrics    17.93725ms
[Debug] StartTimer: source[89](v15.3.2)GetReleaseMetrics
[Debug] Stop_Timer: source[89](v15.3.2)GetReleaseMetrics         17.524917ms
[Debug] StartTimer: source[90](15.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[90](15.3.1)GetReleaseMetrics          8µs
[Debug] StartTimer: source[91](v15.3.1)GetReleaseMetrics
[Debug] Stop_Timer: source[91](v15.3.1)GetReleaseMetrics         17.555ms
[Debug] StartTimer: source[92](v15.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[92](v15.3.0)GetReleaseMetrics         17.218792ms
[Debug] StartTimer: source[93](v15.2.1)GetReleaseMetrics
[Debug] Stop_Timer: source[93](v15.2.1)GetReleaseMetrics         17.690625ms
[Debug] StartTimer: source[94](v15.2.0)GetReleaseMetrics
[Debug] Stop_Timer: source[94](v15.2.0)GetReleaseMetrics         17.881084ms
[Debug] StartTimer: source[95](v15.1.0)GetReleaseMetrics
[Debug] Stop_Timer: source[95](v15.1.0)GetReleaseMetrics         17.581708ms
[Debug] StartTimer: source[96](v15.0.2)GetReleaseMetrics
[Debug] Stop_Timer: source[96](v15.0.2)GetReleaseMetrics         17.16375ms
[Debug] StartTimer: source[97](v15.0.1)GetReleaseMetrics
[Debug] Stop_Timer: source[97](v15.0.1)GetReleaseMetrics         16.690292ms
[Debug] StartTimer: source[98](v15.0.0)GetReleaseMetrics
[Debug] Stop_Timer: source[98](v15.0.0)GetReleaseMetrics         16.463875ms
[Debug] StartTimer: source[99](v0.14.8)GetReleaseMetrics
[Debug] Stop_Timer: source[99](v0.14.8)GetReleaseMetrics         14.301875ms
[Debug] StartTimer: source[100](v15.0.0-rc.2)GetReleaseMetrics
[Debug] Stop_Timer: source[100](v15.0.0-rc.2)GetReleaseMetrics   16.253458ms
[Debug] StartTimer: source[101](v15.0.0-rc.1)GetReleaseMetrics
[Debug] Stop_Timer: source[101](v15.0.0-rc.1)GetReleaseMetrics   16.476458ms
[Debug] StartTimer: source[102](v0.14.7)GetReleaseMetrics
[Debug] Stop_Timer: source[102](v0.14.7)GetReleaseMetrics        14.368333ms
[Debug] StartTimer: source[103](v0.14.6)GetReleaseMetrics
[Debug] Stop_Timer: source[103](v0.14.6)GetReleaseMetrics        14.607875ms
[Debug] StartTimer: source[104](v0.14.5)GetReleaseMetrics
[Debug] Stop_Timer: source[104](v0.14.5)GetReleaseMetrics        14.610458ms
[Debug] StartTimer: source[105](v0.14.4)GetReleaseMetrics
[Debug] Stop_Timer: source[105](v0.14.4)GetReleaseMetrics        14.211542ms
[Debug] StartTimer: source[106](v0.14.3)GetReleaseMetrics
[Debug] Stop_Timer: source[106](v0.14.3)GetReleaseMetrics        14.19975ms
[Debug] StartTimer: source[107](v0.14.2)GetReleaseMetrics
[Debug] Stop_Timer: source[107](v0.14.2)GetReleaseMetrics        14.885792ms
[Debug] StartTimer: source[108](v0.14.1)GetReleaseMetrics
[Debug] Stop_Timer: source[108](v0.14.1)GetReleaseMetrics        14.989541ms
[Debug] StartTimer: source[109](v0.14.0)GetReleaseMetrics
[Debug] Stop_Timer: source[109](v0.14.0)GetReleaseMetrics        15.213709ms
[Debug] StartTimer: source[110](v0.14.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[110](v0.14.0-rc1)GetReleaseMetrics    14.263875ms
[Debug] StartTimer: source[111](v0.14.0-beta3)GetReleaseMetrics
[Debug] Stop_Timer: source[111](v0.14.0-beta3)GetReleaseMetrics          13.725875ms
[Debug] StartTimer: source[112](v0.14.0-beta2)GetReleaseMetrics
[Debug] Stop_Timer: source[112](v0.14.0-beta2)GetReleaseMetrics          13.477292ms
[Debug] StartTimer: source[113](v0.14.0-beta1)GetReleaseMetrics
[Debug] Stop_Timer: source[113](v0.14.0-beta1)GetReleaseMetrics          13.249875ms
[Debug] StartTimer: source[114](v0.13.3)GetReleaseMetrics
[Debug] Stop_Timer: source[114](v0.13.3)GetReleaseMetrics        10.760667ms
[Debug] StartTimer: source[115](v0.13.2)GetReleaseMetrics
[Debug] Stop_Timer: source[115](v0.13.2)GetReleaseMetrics        10.662ms
[Debug] StartTimer: source[116](v0.13.1)GetReleaseMetrics
[Debug] Stop_Timer: source[116](v0.13.1)GetReleaseMetrics        10.408708ms
[Debug] StartTimer: source[117](v0.13.0)GetReleaseMetrics
[Debug] Stop_Timer: source[117](v0.13.0)GetReleaseMetrics        10.481708ms
[Debug] StartTimer: source[118](v0.13.0-rc2)GetReleaseMetrics
[Debug] Stop_Timer: source[118](v0.13.0-rc2)GetReleaseMetrics    10.007917ms
[Debug] StartTimer: source[119](v0.13.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[119](v0.13.0-rc1)GetReleaseMetrics    10.420458ms
[Debug] StartTimer: source[120](v0.12.2)GetReleaseMetrics
[Debug] Stop_Timer: source[120](v0.12.2)GetReleaseMetrics        8.114083ms
[Debug] StartTimer: source[121](v0.12.1)GetReleaseMetrics
[Debug] Stop_Timer: source[121](v0.12.1)GetReleaseMetrics        7.950542ms
[Debug] StartTimer: source[122](v0.12.0)GetReleaseMetrics
[Debug] Stop_Timer: source[122](v0.12.0)GetReleaseMetrics        7.76575ms
[Debug] StartTimer: source[123](v0.12.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[123](v0.12.0-rc1)GetReleaseMetrics    7.730584ms
[Debug] StartTimer: source[124](v0.11.2)GetReleaseMetrics
[Debug] Stop_Timer: source[124](v0.11.2)GetReleaseMetrics        6.822541ms
[Debug] StartTimer: source[125](v0.11.1)GetReleaseMetrics
[Debug] Stop_Timer: source[125](v0.11.1)GetReleaseMetrics        6.608834ms
[Debug] StartTimer: source[126](v0.11.0)GetReleaseMetrics
[Debug] Stop_Timer: source[126](v0.11.0)GetReleaseMetrics        6.550667ms
[Debug] StartTimer: source[127](v0.11.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[127](v0.11.0-rc1)GetReleaseMetrics    6.49025ms
[Debug] StartTimer: source[128](v0.10.0)GetReleaseMetrics
[Debug] Stop_Timer: source[128](v0.10.0)GetReleaseMetrics        5.047084ms
[Debug] StartTimer: source[129](v0.10.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[129](v0.10.0-rc1)GetReleaseMetrics    5.215125ms
[Debug] StartTimer: source[130](v0.9.0)GetReleaseMetrics
[Debug] Stop_Timer: source[130](v0.9.0)GetReleaseMetrics         4.799ms
[Debug] StartTimer: source[131](v0.9.0-rc1)GetReleaseMetrics
[Debug] Stop_Timer: source[131](v0.9.0-rc1)GetReleaseMetrics     4.766625ms
[Debug] StartTimer: source[132](v0.8.0)GetReleaseMetrics
[Debug] Stop_Timer: source[132](v0.8.0)GetReleaseMetrics         2.146625ms
[Debug] StartTimer: source[133](v0.5.2)GetReleaseMetrics
[Debug] Stop_Timer: source[133](v0.5.2)GetReleaseMetrics         2.121375ms
[Debug] StartTimer: source[134](v0.4.2)GetReleaseMetrics
[Debug] Stop_Timer: source[134](v0.4.2)GetReleaseMetrics         1.581416ms
[Debug] StartTimer: source[135](v0.5.1)GetReleaseMetrics
[Debug] Stop_Timer: source[135](v0.5.1)GetReleaseMetrics         1.994875ms
[Debug] StartTimer: source[136](v0.5.0)GetReleaseMetrics
[Debug] Stop_Timer: source[136](v0.5.0)GetReleaseMetrics         1.851209ms
[Debug] StartTimer: source[137](v0.4.1)GetReleaseMetrics
[Debug] Stop_Timer: source[137](v0.4.1)GetReleaseMetrics         1.311625ms
[Debug] StartTimer: source[138](v0.4.0)GetReleaseMetrics
[Debug] Stop_Timer: source[138](v0.4.0)GetReleaseMetrics         1.255959ms
[Debug] StartTimer: source[139](v0.3.3)GetReleaseMetrics
[Debug] Stop_Timer: source[139](v0.3.3)GetReleaseMetrics         403.625µs
[Debug] StartTimer: source[140](v0.3.0)GetReleaseMetrics
[Debug] Stop_Timer: source[140](v0.3.0)GetReleaseMetrics         6.042µs
[Debug] Stop_Timer: QueryReleases        3.003893708s
[Debug] StartTimer: Calculate metrics
[Debug] Stop_Timer: Calculate metrics    230.667µs
{"option":{"since":"2000-01-01T00:00:00Z","until":"2022-07-28T22:08:53.864109+09:00"},"deploymentFrequency":0.01710334788937409,"leadTimeForChanges":{"value":19.696861045442606,"unit":"day"},"timeToRestore":{"value":110.39109953703705,"unit":"day"},"changeFailureRate":0.014184397163120567}
________________________________________________________
Executed in   54.42 secs    fish           external
   usr time   12.90 secs    0.14 millis   12.90 secs
   sys time    2.33 secs    1.61 millis    2.33 secs
```

</details>