### PR TITLE
really ignore release

### DIFF
--- a/internal/core/query_releases_test.go
+++ b/internal/core/query_releases_test.go
@@ -126,26 +126,24 @@ func TestQueryReleasesShouldHaveReleaseResult(t *testing.T) {
 }
 
 func TestQueryReleasesShouldReturnReleasesWithIgnorePattern(t *testing.T) {
-	pattern, _ := regexp.Compile(`v5\.1\.0|v5\.2\.0`)
+	pattern, _ := regexp.Compile(`v5\.0\.0|v5\.2\.0`)
 	releases := QueryReleases(repository, &Option{
 		Since:         time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Until:         time.Date(2020, 12, 31, 23, 59, 59, 999, time.UTC),
 		IgnorePattern: pattern,
 	})
-	tag5_0_0 := &Release{Tag: "v5.0.0", Date: time.Date(2020, 3, 15, 21, 18, 32, 0, time.FixedZone("+0100", 1*60*60))}
-	expectedTags := []*Release{tag5_0_0}
-
-	if len(releases) != len(expectedTags) {
-		t.Errorf("releases does not have expected tag num. expected: %v. actual: %v", len(expectedTags), len(releases))
-		return
+	tag5_1_0 := &Release{
+		Tag:                "v5.1.0",
+		Date:               time.Date(2020, 5, 24, 19, 25, 8, 0, time.FixedZone("+0200", 2*60*60)),
+		LeadTimeForChanges: time.Duration(25454673000000000),
+		Result: ReleaseResult{
+			IsSuccess:     true,
+			TimeToRestore: nil,
+		},
 	}
+	expectedTags := []*Release{tag5_1_0}
 
-	if releases[0].Tag == tag5_0_0.Tag {
-		return
-	}
-
-	t.Logf("expected: %v, actual: %v", tag5_0_0, releases[0])
-	t.Errorf("releases does not have specified")
+	assertReleasesAreEqual(t, expectedTags, releases)
 }
 
 func TestQueryReleasesShouldReturnSameReleasesRepositoryIsLocalOrNot(t *testing.T) {


### PR DESCRIPTION
Ignored releases are really ignored even in lead time for changes.

Example:
For these v5.0.0, v5.1.0, v5.2.0
```
./four-keys releases --repository https://github.com/go-git/go-git --since 2020-01-01 --until 2020-12-31  | jq
{
  "option": {
    "since": "2020-01-01T00:00:00Z",
    "until": "2020-12-31T23:59:59Z"
  },
  "releases": [
    {
      "tag": "v5.2.0",
      "date": "2020-10-09T11:49:30+02:00",
      "leadTimeForChanges": {
        "value": 130.77916666666667,
        "unit": "day"
      },
      "result": {
        "isSuccess": true,
        "timeToRestore": null
      }
    },
    {
      "tag": "v5.1.0",
      "date": "2020-05-24T19:25:08+02:00",
      "leadTimeForChanges": {
        "value": 69.86515046296296,
        "unit": "day"
      },
      "result": {
        "isSuccess": true,
        "timeToRestore": null
      }
    },
    {
      "tag": "v5.0.0",
      "date": "2020-03-15T21:18:32+01:00",
      "leadTimeForChanges": {
        "value": 224.73468749999998,
        "unit": "day"
      },
      "result": {
        "isSuccess": true,
        "timeToRestore": null
      }
    }
  ]
}
```

Before:
Ignore v5.0.0 but lead time for changes in v5.1.0 does not change.
```
./four-keys releases --repository https://github.com/go-git/go-git --since 2020-01-01 --until 2020-12-31 --ignorePattern "v5.0.0|v5.2.0" | jq
{
  "option": {
    "since": "2020-01-01T00:00:00Z",
    "until": "2020-12-31T23:59:59Z"
  },
  "releases": [
    {
      "tag": "v5.1.0",
      "date": "2020-05-24T19:25:08+02:00",
      "leadTimeForChanges": {
        "value": 69.86515046296296,
        "unit": "day"
      },
      "result": {
        "isSuccess": true,
        "timeToRestore": null
      }
    }
  ]
```

After(this PR):
v5.0.0 is really ignored and lead time for changes in v5.1.0 is changed.
The lead time for changes in v5.1.0 with ignoring v5.0.0 (294days) is almost sum of lead time for changes of v5.0.0(224days) and v5.1.0(69days) without ignoring.
```
./four-keys releases --repository https://github.com/go-git/go-git --since 2020-01-01 --until 2020-12-31 --ignorePattern "v5.0.0|v5.2.0" | jq
{
  "option": {
    "since": "2020-01-01T00:00:00Z",
    "until": "2020-12-31T23:59:59Z"
  },
  "releases": [
    {
      "tag": "v5.1.0",
      "date": "2020-05-24T19:25:08+02:00",
      "leadTimeForChanges": {
        "value": 294.61427083333336,
        "unit": "day"
      },
      "result": {
        "isSuccess": true,
        "timeToRestore": null
      }
    }
  ]
}
```